### PR TITLE
data-type attribute support

### DIFF
--- a/ujs/jquery.js
+++ b/ujs/jquery.js
@@ -15,7 +15,7 @@ $("form[data-remote=true]").live('submit', function(e) {
   JSAdapter.sendRequest(element, { 
     verb: element.data('method') || element.attr('method') || 'post', 
     url: element.attr('action'), 
-    dataType: element.data('type') || ($.ajaxSettings && $.ajaxSettings.dataType),
+    dataType: element.data('type') || ($.ajaxSettings && $.ajaxSettings.dataType) || 'script',
     params: element.serializeArray()
   });
 });


### PR DESCRIPTION
eg.: `data-type="html"` becomes `$.ajax({ dataType: 'html' })` behind the scenes
