### PR TITLE
Switch e.target to this for nested elements

### DIFF
--- a/ujs/jquery.js
+++ b/ujs/jquery.js
@@ -50,8 +50,9 @@ $("a[data-remote=true]").live('click', function(e) {
 **/
 
 $("a[data-method]:not([data-remote])").live('click', function(e) {
+  var element = $(this); 
   if (e.stopped) return;
-  JSAdapter.sendMethod($(e.target));
+  JSAdapter.sendMethod(element);
   e.preventDefault(); e.stopped = true;
 });
 


### PR DESCRIPTION
<pre>
!= link_to url(:entry, :destroy, :eid => entry.eid), :method => :delete do
  %i.icon-remove
</pre>


<pre>
&lt;a href="/sample/entries/destroy/123" data-method="delete" rel="nofollow"&gt;
&lt;i class='icon-remove' &gt;&lt;/i&gt;
&lt;/a&gt;
</pre>


When we click "remove icon", "e.target" is "&lt;i class='icon-remove' /&gt;".
And it does not have "data-method" and "href".
"e.target" should be "e.currentTarget" or "this".
