### PR TITLE
Updating jquery's ujs

### DIFF
--- a/ujs/jquery.js
+++ b/ujs/jquery.js
@@ -7,10 +7,9 @@
  * form_for @user, '/user', :remote => true
 **/
 
-$("form[data-remote=true]").live('submit', function(e) {
+$('form[data-remote=true]').on('submit', function(e) {
   e.preventDefault(); e.stopped = true;
-  var element = $(this);
-  var message = element.data('confirm');
+  var element = $(this), message = element.data('confirm');
   if (message && !confirm(message)) { return false; }
   JSAdapter.sendRequest(element, { 
     verb: element.data('method') || element.attr('method') || 'post', 
@@ -21,10 +20,10 @@ $("form[data-remote=true]").live('submit', function(e) {
 });
 
 /* Confirmation Support
- * link_to 'sign out', '/logout', :confirm => "Log out?"
+ * link_to 'sign out', '/logout', :confirm => 'Log out?'
 **/
 
-$("a[data-confirm]").live('click', function(e) {
+$('a[data-confirm]').on('click', function(e) {
   var message = $(this).data('confirm');
   if (!confirm(message)) { e.preventDefault(); e.stopped = true; }
 });
@@ -34,7 +33,7 @@ $("a[data-confirm]").live('click', function(e) {
  * link_to 'add item', '/create', :remote => true
 **/
 
-$("a[data-remote=true]").live('click', function(e) {
+$('a[data-remote=true]').on('click', function(e) {
   var element = $(this); 
   if (e.stopped) return;
   e.preventDefault(); e.stopped = true;
@@ -49,10 +48,9 @@ $("a[data-remote=true]").live('click', function(e) {
  * link_to 'delete item', '/destroy', :method => :delete
 **/
 
-$("a[data-method]:not([data-remote])").live('click', function(e) {
-  var element = $(this); 
+$('a[data-method]:not([data-remote])').on('click', function(e) {
   if (e.stopped) return;
-  JSAdapter.sendMethod(element);
+  JSAdapter.sendMethod($(this));
   e.preventDefault(); e.stopped = true;
 });
 
@@ -60,9 +58,9 @@ $("a[data-method]:not([data-remote])").live('click', function(e) {
 var JSAdapter = {
   // Sends an xhr request to the specified url with given verb and params
   // JSAdapter.sendRequest(element, { verb: 'put', url : '...', params: {} });
-  sendRequest : function(element, options) {
+  sendRequest: function(element, options) {
     var verb = options.verb, url = options.url, params = options.params, dataType = options.dataType;
-    var event = element.trigger("ajax:before");
+    var event = element.trigger('ajax:before');
     if (event.stopped) return false;
     $.ajax({
       url: url,
@@ -70,16 +68,16 @@ var JSAdapter = {
       data: params || [],
       dataType: dataType,
 
-      beforeSend: function(request) { element.trigger("ajax:loading",  [ request ]); },
-      complete:   function(request) { element.trigger("ajax:complete", [ request ]); },
-      success:    function(request) { element.trigger("ajax:success",  [ request ]); },
-      error:      function(request) { element.trigger("ajax:failure",  [ request ]); }
+      beforeSend: function(request) { element.trigger('ajax:loading',  [ request ]); },
+      complete:   function(request) { element.trigger('ajax:complete', [ request ]); },
+      success:    function(request) { element.trigger('ajax:success',  [ request ]); },
+      error:      function(request) { element.trigger('ajax:failure',  [ request ]); }
     });
-    element.trigger("ajax:after");
+    element.trigger('ajax:after');
   },
   // Triggers a particular method verb to be triggered in a form posting to the url
   // JSAdapter.sendMethod(element);
-  sendMethod : function(element) {
+  sendMethod: function(element) {
     var verb = element.data('method');
     var url = element.attr('href');
     var form = $('<form method="post" action="'+url+'"></form>');


### PR DESCRIPTION
- Using `on` instead of `live`.
- Normalised the usage of quotes to single quotes and colons.
  Note: didn't update jquery to the latest stable because @WayDotNet did it here padrino/padrino-static#8.
