### PR TITLE
Show confirm on form

### DIFF
--- a/ujs/jquery.js
+++ b/ujs/jquery.js
@@ -8,16 +8,18 @@
 **/
 
 $(function(){
-    $('form[data-remote=true]').on('submit', function(e) {
-      e.preventDefault(); e.stopped = true;
+    $('form').on('submit', function(e) {
       var element = $(this), message = element.data('confirm');
       if (message && !confirm(message)) { return false; }
-      JSAdapter.sendRequest(element, {
-        verb: element.data('method') || element.attr('method') || 'post',
-        url: element.attr('action'),
-        dataType: element.data('type') || ($.ajaxSettings && $.ajaxSettings.dataType) || 'script',
-        params: element.serializeArray()
-      });
+      if (element.data('remote') == true) {
+        e.preventDefault(); e.stopped = true;
+        JSAdapter.sendRequest(element, {
+          verb: element.data('method') || element.attr('method') || 'post',
+          url: element.attr('action'),
+          dataType: element.data('type') || ($.ajaxSettings && $.ajaxSettings.dataType) || 'script',
+          params: element.serializeArray()
+        });
+      }
     });
 
     /* Confirmation Support


### PR DESCRIPTION
If request submit from form which has `data-confirm` attribute, but has no `data-remote=true`, confirm dialog is not shown.
By handling submit based on `data-confirm` attribute, this commit enables it to show confirm dialog even if the form tag has no `data-remote=true` attribute.
